### PR TITLE
Fix occupancy grid republisher logic

### DIFF
--- a/rosboard_client/rosboard_client/ros/republishers/occupancy_grid.py
+++ b/rosboard_client/rosboard_client/ros/republishers/occupancy_grid.py
@@ -61,19 +61,18 @@ class OccupancyGridPublisher(GenericPublisher):
             "nav_msgs/msg/OccupancyGrid", rosboard_data[1], strict_mode=False
         )
         # adjust resolution for rosboard subsampling
-        image_bytes = cv2.rotate(image_bytes, cv2.ROTATE_90_CLOCKWISE)
         base_occupancy_grid.info.resolution = base_occupancy_grid.info.resolution * (
             base_occupancy_grid.info.width / image_bytes.shape[0]
         )
 
         # adjust size for rosboard subsampling
-        base_occupancy_grid.info.width = image_bytes.shape[0]
-        base_occupancy_grid.info.height = image_bytes.shape[1]
+        base_occupancy_grid.info.width = image_bytes.shape[1]
+        base_occupancy_grid.info.height = image_bytes.shape[0]
 
         occupancy_grid_array = image_bytes.astype(np.int8)
 
         base_occupancy_grid.data = (
-            occupancy_grid_array.flatten("F").astype(np.int8).tolist()
+            occupancy_grid_array.flatten("C").astype(np.int8).tolist()
         )
         return base_occupancy_grid
 


### PR DESCRIPTION
With https://github.com/kiwicampus/rosboard/pull/19 we don't need to rotate the occupancy grid data as they already come ready to be replublished.
Fixed height and width params of republisher
Fixed flatten logic